### PR TITLE
Test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This opens the language server part and the client part of the plugin in two dif
 
 To try out the changes, go to the client editor and press `F5`. A new instance of Visual Studio Code will be started that has the Dafny plugin running and ready for testing. Sometimes, Visual Studio Code does not recognize changes and does not apply them to the running test instance. If this is the case, simply close and restart the test instance, the changes should then be applied.
 
-If you wish to contribute, simply make your changes and submit a pull request. Make sure that your changes don't break the existing tests in the client/test folder. You can run the tests with `npm test` while in the client folder. Feel free to add any tests.
+If you wish to contribute, simply make your changes and submit a pull request. Make sure that your changes don't break the existing tests in the client/test folder. You can run the tests with `npm test` while in the client folder. For this to work, you have to set environment variable `DAFNY_PATH` on your system to your _Dafny_ release (without a "/" at the end of the path). Feel free to add any tests.
 
 ## Release
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -26,7 +26,11 @@ Build the server and the client as described in [README.md](README.md).
 Run the following commands in the root of the repository:
 
 * `vsce login FunctionalCorrectness`
-* `vsce publish minor`
+* Depending on your changes:
+  * `vsce publish patch` (if you only committed bug fixes)
+  * `vsce publish minor` (if you introduced new features)
+  * `vsce publish major` (if backward compatibility is no longer given)
+* Note: This will automatically adjust your _package.json_ file.
 * Hint 1: For this to work, you need the proper permissions (manage permissions [here](https://marketplace.visualstudio.com/manage/publishers/FunctionalCorrectness?auth_redirect=True)).
 * Hint 2: All the information about publishing extensions can be found [here](https://code.visualstudio.com/docs/extensions/publish-extension).
 

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## 0.12.0
+The Dafny base path can now alternatively be set via the environment variable DAFNY_PATH.
+
 ## 0.11.1 
 Use Dafny releases from Microsoft/dafny. Miscellaneous bug fixes.
 

--- a/server/src/backend/environment.ts
+++ b/server/src/backend/environment.ts
@@ -32,11 +32,11 @@ export class Environment {
     }
 
     public getStartDafnyCommand(): Command {
-        return this.getCommand(this.dafnySettings.basePath + "/" + Application.DafnyServer);
+        return this.getCommand(this.getBasePath() + "/" + Application.DafnyServer);
     }
 
     public getDafnyExe(): Command {
-        return this.getCommand(this.dafnySettings.basePath + "/" + Application.Dafny);
+        return this.getCommand(this.getBasePath() + "/" + Application.Dafny);
     }
 
     public getStandardSpawnOptions(): cp.SpawnOptions {
@@ -67,6 +67,23 @@ export class Environment {
         }
         return monoPath;
     }
+
+    /**
+     * Determines the Dafny base path either from the configuration set in the Dafny settings,
+     * or, if not available from there, from the environment variable DAFNY_PATH.
+     * @return {String} A string containing the determined Dafny base path.
+     */
+    private getBasePath(): String {
+        if(this.dafnySettings.basePath === "") {
+            if(process.env.DAFNY_PATH === undefined || process.env.DAFNY_PATH === "") {
+                return "";
+            } else {
+                return process.env.DAFNY_PATH;
+            }
+        }
+        return this.dafnySettings.basePath;
+    }
+
     private getCommand(commandName: string): Command {
         let baseCommand: string;
         let args: string[];


### PR DESCRIPTION
Added possibility, to set environment variable DAFNY_PATH instead of defining it via the VSCode settings. This fixes the test suite and allows for possible CI later on.