### PR TITLE
Fixed reference CodeLens no working

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -63,7 +63,7 @@ export function activate(context: vscode.ExtensionContext) {
     const disposable = languageServer.start();
     context.subscriptions.push(disposable);
 
-    vscode.commands.registerCommand(Commands.ShowReferences, (uri: vscode.Uri, position, locations) => {
+    vscode.commands.registerCommand(Commands.ShowReferences, (uri, position, locations) => {
         function parsePosition(p: any): vscode.Position {
             return new vscode.Position(p.line, p.character);
         }
@@ -77,7 +77,7 @@ export function activate(context: vscode.ExtensionContext) {
             return vscode.Uri.file(u);
         }
 
-        const parsedUri = vscode.Uri.file(uri.fsPath);
+        const parsedUri = vscode.Uri.file(uri);
         const parsedPosition = parsePosition(position);
         const parsedLocations = [];
         for (const location of locations) {

--- a/server/src/backend/features/referenceCodeLensProvider.ts
+++ b/server/src/backend/features/referenceCodeLensProvider.ts
@@ -37,7 +37,7 @@ export class DafnyReferencesCodeLensProvider extends DafnyBaseCodeLensProvider {
         const locations = this.buildReferenceLocations(referenceInformation);
 
         codeLens.command = {
-            arguments: [Uri.parse(codeLens.symbol.document.uri), codeLens.range.start, locations],
+            arguments: [Uri.parse(codeLens.symbol.document.uri).fsPath, codeLens.range.start, locations],
             command: Commands.ShowReferences,
             title: locations.length === 1
                 ? "1 reference"


### PR DESCRIPTION
Fixed reference CodeLens no working from a change in the internal Uri of vscode making it not work.


When clicking on the reference text a popup showed 
`Running the contributed command:'dafny.showReferences' failed.`
and in the log this was outputted:
```
[2018-11-27 04:13:13.750] [exthost] [error] TypeError: Cannot read property '0' of undefined
	at Function.e.file (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/node/extensionHostProcess.js:51:796)
	at vscode.commands.registerCommand (/Users/gustaf/.vscode/extensions/functionalcorrectness.dafny-vscode-0.12.0/out/src/extension.js:67:38)
	at e._executeContributedCommand (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/node/extensionHostProcess.js:460:160)
	at e.executeCommand (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/node/extensionHostProcess.js:459:458)
	at e._executeConvertedCommand (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/node/extensionHostProcess.js:462:42)
	at e._executeContributedCommand (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/node/extensionHostProcess.js:460:160)
	at e.$executeContributedCommand (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/node/extensionHostProcess.js:460:648)
	at t._doInvokeHandler (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/node/extensionHostProcess.js:609:757)
	at t._invokeHandler (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/node/extensionHostProcess.js:609:423)
	at t._receiveRequest (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/node/extensionHostProcess.js:608:15)
	at t._receiveOneMessage (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/node/extensionHostProcess.js:606:957)
	at /Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/node/extensionHostProcess.js:604:773
	at /Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/node/extensionHostProcess.js:103:886
	at e.fire (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/node/extensionHostProcess.js:105:344)
	at a (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/node/extensionHostProcess.js:156:881)
	at Socket._socketDataListener (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/node/extensionHostProcess.js:157:95)
	at emitOne (events.js:116:13)
	at Socket.emit (events.js:211:7)
	at addChunk (_stream_readable.js:263:12)
	at readableAddChunk (_stream_readable.js:250:11)
	at Socket.Readable.push (_stream_readable.js:208:10)
	at Pipe.onread (net.js:594:20) dafny.showReferences
```

This pull request fixes this issue.