### PR TITLE
Allow customizing the arguments passed to the verify backend

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -62,6 +62,7 @@ The following are optional:
 | `dafny.automaticVerification` | Verify as soon as the document is changed (default). When false, only verify on save. |
 | `dafny.automaticVerificationDelayMS` | Delay to wait after a document change before actually sending a verification request. This is done to avoid getting syntax errors as one is typing. Only relevant when automaticVerification is true. |
 | `dafny.automaticShowCounterModel` | Show _CounterModel_ automatically if a proof fails. Can cause performance issues. |
+| `dafny.serverVerifyArguments` | Additional arguments to pass to the "verify" command of the Dafny Server. E.g.`["/timeLimit:40", "/vcsLoad:1"]` |
 
 ## Examples
 

--- a/client/package.json
+++ b/client/package.json
@@ -161,6 +161,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Show countermodel if a program does not hold. Can cause much longer verification time."
+                },
+                "dafny.serverVerifyArguments": {
+                    "type": "array",
+                    "default": [],
+                    "description": "Arguments to pass to the \"verify\" command of the Dafny Server. E.g., [\"/timeLimit:40\", \"/vcsLoad:1\"] "
                 }
             }
         },

--- a/server/src/backend/dafnyServer.ts
+++ b/server/src/backend/dafnyServer.ts
@@ -197,7 +197,7 @@ export class DafnyServer {
             this.statusbar.changeServerStatus(StatusString.Verifying);
         }
         const task: IVerificationTask = {
-            args: [],
+            args: this.settings.serverVerifyArguments,
             filename: Uri.parse(request.document.uri).fsPath,
             source: request.source,
             sourceIsFile: false,

--- a/server/src/backend/dafnySettings.ts
+++ b/server/src/backend/dafnySettings.ts
@@ -6,4 +6,5 @@ export interface IDafnySettings {
     monoPath: string;
     automaticVerification: boolean;
     automaticVerificationDelayMS: number;
+    serverVerifyArguments: string[];
 }


### PR DESCRIPTION
The verification backend now can receive arguments passed as
an array in the user configuration.

Currently the configuration seems to be loaded only once, and
the onDidChangeConfiguration event handler seems not to be
appropriately hot-reloading the settings.

Current workaround: reload the extension by reloading the window.

This addresses #41 