### PR TITLE
Fix no reporting of "timed out after" errors

### DIFF
--- a/client/test/sampleFolder/timedout_after.dfy
+++ b/client/test/sampleFolder/timedout_after.dfy
@@ -1,0 +1,114 @@
+lemma lemma_mul_basics_forall()
+    ensures forall x:int  :: 0*x == 0;
+    ensures forall x:int  :: x*0 == 0;
+    ensures forall x:int  :: 1*x == x;
+    ensures forall x:int  :: x*1 == x;
+
+
+lemma lemma_mul_ordering_forall()
+    ensures forall x:int, y:int  ::
+        0 < x && 0 < y && 0 <= x*y
+        ==> x <= x*y && y <= x*y;
+
+
+lemma lemma_mul_strict_inequality_forall()
+    ensures  forall x:int, y:int, z:int  ::
+        x < y && z>0 ==> x*z < y*z;
+
+
+lemma lemma_mul_inequality_forall()
+    ensures  forall x:int, y:int, z:int  ::
+        x <= y && z>=0 ==> x*z <= y*z;
+
+lemma lemma_mul_is_distributive_forall()
+    ensures forall x:int, y:int, z:int  :: x*(y + z) == x*y + x*z;
+    ensures forall x:int, y:int, z:int  :: x*(y - z) == x*y - x*z;
+    ensures forall x:int, y:int, z:int  :: (y + z)*x == y*x + z*x;
+    ensures forall x:int, y:int, z:int  :: (y - z)*x == y*x - z*x;
+
+
+lemma lemma_mul_is_associative_forall()
+    ensures forall x:int, y:int, z:int  :: x * (y * z) == (x * y) * z;
+
+
+lemma lemma_mul_nonnegative_forall()
+    ensures forall x:int, y:int  :: 0 <= x && 0 <= y ==> 0 <= x*y;
+
+
+lemma lemma_mul_strictly_increases_forall()
+    ensures forall x:int, y:int  :: (1 < x && 0 < y) ==> (y < x*y);
+
+
+lemma lemma_mul_increases_forall()
+    ensures forall x:int, y:int  :: (0 < x && 0 < y) ==> (y <= x*y);
+
+lemma lemma_mul_strictly_positive_forall()
+    ensures forall x:int, y:int  :: (0 < x && 0 < y) ==> (0 < x*y);
+
+lemma lemma_mul_nonzero_forall()
+    ensures forall x:int, y:int  :: x*y != 0 <==> x != 0 && y != 0;
+
+//////////////////////////////////////////////////////////////////////////////
+//
+// The big properties bundle. This can be a little dangerous, because
+// it may produce a trigger storm. Whether it does seems to depend on
+// how complex the expressions being mul'ed are. If that happens,
+// fall back on specifying an individiual _forall lemma or use
+// lemma_mul_auto/lemma_mul_auto_induction.
+//
+//////////////////////////////////////////////////////////////////////////////
+
+lemma lemma_mul_properties()
+    ensures forall x:int, y:int  :: x*y == y*x;
+    ensures forall x:int  :: x*0 == 0*x == 0;
+    ensures forall x:int  :: x*1 == 1*x == x;
+    ensures forall x:int, y:int, z:int  :: x < y && z > 0 ==> x*z < y*z;
+    ensures forall x:int, y:int, z:int  :: x <= y && z >= 0 ==> x*z <= y*z;
+    
+    ensures forall x:int, y:int, z:int  :: x*(y*z) == (x*y)*z;
+    ensures forall x:int, y:int  :: x*y != 0 <==> x != 0 && y != 0;
+    ensures forall x:int, y:int  :: 0 <= x && 0 <= y ==> 0 <= x*y;
+    ensures forall x:int, y:int  :: 0 < x && 0 < y && 0 <= x*y ==> x <= x*y && y <= x*y;
+    ensures forall x:int, y:int  :: (1 < x && 0 < y) ==> (y < x*y);
+    ensures forall x:int, y:int  :: (0 < x && 0 < y) ==> (y <= x*y);
+    ensures forall x:int, y:int  :: (0 < x && 0 < y) ==> (0 < x*y);
+{
+    lemma_mul_basics_forall();
+    // assert forall x:int, y:int  :: x*y == y*x;
+    // assert forall x:int  :: x*0 == 0*x == 0;
+    // assert forall x:int  :: x*1 == 1*x == x;
+
+    lemma_mul_strictly_positive_forall();
+    // assert forall x:int, y:int  :: (0 < x && 0 < y) ==> (0 < x*y);
+
+    lemma_mul_strict_inequality_forall();
+    // assert forall x:int, y:int, z:int  :: x < y && z > 0 ==> x*z < y*z;
+
+    lemma_mul_inequality_forall();
+    // assert forall x:int, y:int, z:int  :: x <= y && z >= 0 ==> x*z <= y*z;
+
+    lemma_mul_is_distributive_forall();
+    // assert forall x:int, y:int, z:int  :: x*(y + z) == x*y + x*z;
+    // assert forall x:int, y:int, z:int  :: x*(y - z) == x*y - x*z;
+    // assert forall x:int, y:int, z:int  :: (y + z)*x == y*x + z*x;
+    // assert forall x:int, y:int, z:int  :: (y - z)*x == y*x - z*x;
+
+    lemma_mul_is_associative_forall();
+    // assert forall x:int, y:int, z:int  :: x*(y*z) == (x*y)*z;
+
+    lemma_mul_ordering_forall();
+    // assert forall x:int, y:int  :: 0 < x && 0 < y && 0 <= x*y ==> x <= x*y && y <= x*y;
+
+    lemma_mul_nonzero_forall();
+    // assert forall x:int, y:int  :: x*y != 0 <==> x != 0 && y != 0;
+
+    lemma_mul_nonnegative_forall();
+    // assert forall x:int, y:int  :: 0 <= x && 0 <= y ==> 0 <= x*y;
+
+    lemma_mul_strictly_increases_forall();
+    // assert forall x:int, y:int  :: (1 < x && 0 < y) ==> (y < x*y);
+
+
+    lemma_mul_increases_forall();
+    // assert forall x:int, y:int  :: (0 < x && 0 < y) ==> (y <= x*y);
+}

--- a/client/test/sampleFolder/timedout_after.dfy
+++ b/client/test/sampleFolder/timedout_after.dfy
@@ -1,70 +1,33 @@
-lemma lemma_mul_basics_forall()
-    ensures forall x:int  :: 0*x == 0;
-    ensures forall x:int  :: x*0 == 0;
-    ensures forall x:int  :: 1*x == x;
-    ensures forall x:int  :: x*1 == x;
-
-
-lemma lemma_mul_ordering_forall()
-    ensures forall x:int, y:int  ::
-        0 < x && 0 < y && 0 <= x*y
-        ==> x <= x*y && y <= x*y;
-
-
-lemma lemma_mul_strict_inequality_forall()
-    ensures  forall x:int, y:int, z:int  ::
-        x < y && z>0 ==> x*z < y*z;
-
-
-lemma lemma_mul_inequality_forall()
-    ensures  forall x:int, y:int, z:int  ::
-        x <= y && z>=0 ==> x*z <= y*z;
-
-lemma lemma_mul_is_distributive_forall()
-    ensures forall x:int, y:int, z:int  :: x*(y + z) == x*y + x*z;
-    ensures forall x:int, y:int, z:int  :: x*(y - z) == x*y - x*z;
-    ensures forall x:int, y:int, z:int  :: (y + z)*x == y*x + z*x;
-    ensures forall x:int, y:int, z:int  :: (y - z)*x == y*x - z*x;
-
-
-lemma lemma_mul_is_associative_forall()
-    ensures forall x:int, y:int, z:int  :: x * (y * z) == (x * y) * z;
-
-
-lemma lemma_mul_nonnegative_forall()
-    ensures forall x:int, y:int  :: 0 <= x && 0 <= y ==> 0 <= x*y;
-
-
-lemma lemma_mul_strictly_increases_forall()
-    ensures forall x:int, y:int  :: (1 < x && 0 < y) ==> (y < x*y);
-
-
-lemma lemma_mul_increases_forall()
-    ensures forall x:int, y:int  :: (0 < x && 0 < y) ==> (y <= x*y);
-
-lemma lemma_mul_strictly_positive_forall()
-    ensures forall x:int, y:int  :: (0 < x && 0 < y) ==> (0 < x*y);
-
-lemma lemma_mul_nonzero_forall()
-    ensures forall x:int, y:int  :: x*y != 0 <==> x != 0 && y != 0;
-
-//////////////////////////////////////////////////////////////////////////////
-//
-// The big properties bundle. This can be a little dangerous, because
-// it may produce a trigger storm. Whether it does seems to depend on
-// how complex the expressions being mul'ed are. If that happens,
-// fall back on specifying an individiual _forall lemma or use
-// lemma_mul_auto/lemma_mul_auto_induction.
-//
-//////////////////////////////////////////////////////////////////////////////
+/** This example is taken from
+ * https://github.com/microsoft/Ironclad/blob/master/ironfleet/src/Dafny/Libraries/Math/mul.i.dfy
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the ""Software""), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+*/
 
 lemma lemma_mul_properties()
     ensures forall x:int, y:int  :: x*y == y*x;
-    ensures forall x:int  :: x*0 == 0*x == 0;
-    ensures forall x:int  :: x*1 == 1*x == x;
+    ensures forall x:int :: x*0 == 0*x == 0;
+    ensures forall x:int :: x*1 == 1*x == x;
     ensures forall x:int, y:int, z:int  :: x < y && z > 0 ==> x*z < y*z;
     ensures forall x:int, y:int, z:int  :: x <= y && z >= 0 ==> x*z <= y*z;
-    
     ensures forall x:int, y:int, z:int  :: x*(y*z) == (x*y)*z;
     ensures forall x:int, y:int  :: x*y != 0 <==> x != 0 && y != 0;
     ensures forall x:int, y:int  :: 0 <= x && 0 <= y ==> 0 <= x*y;
@@ -72,43 +35,4 @@ lemma lemma_mul_properties()
     ensures forall x:int, y:int  :: (1 < x && 0 < y) ==> (y < x*y);
     ensures forall x:int, y:int  :: (0 < x && 0 < y) ==> (y <= x*y);
     ensures forall x:int, y:int  :: (0 < x && 0 < y) ==> (0 < x*y);
-{
-    lemma_mul_basics_forall();
-    // assert forall x:int, y:int  :: x*y == y*x;
-    // assert forall x:int  :: x*0 == 0*x == 0;
-    // assert forall x:int  :: x*1 == 1*x == x;
-
-    lemma_mul_strictly_positive_forall();
-    // assert forall x:int, y:int  :: (0 < x && 0 < y) ==> (0 < x*y);
-
-    lemma_mul_strict_inequality_forall();
-    // assert forall x:int, y:int, z:int  :: x < y && z > 0 ==> x*z < y*z;
-
-    lemma_mul_inequality_forall();
-    // assert forall x:int, y:int, z:int  :: x <= y && z >= 0 ==> x*z <= y*z;
-
-    lemma_mul_is_distributive_forall();
-    // assert forall x:int, y:int, z:int  :: x*(y + z) == x*y + x*z;
-    // assert forall x:int, y:int, z:int  :: x*(y - z) == x*y - x*z;
-    // assert forall x:int, y:int, z:int  :: (y + z)*x == y*x + z*x;
-    // assert forall x:int, y:int, z:int  :: (y - z)*x == y*x - z*x;
-
-    lemma_mul_is_associative_forall();
-    // assert forall x:int, y:int, z:int  :: x*(y*z) == (x*y)*z;
-
-    lemma_mul_ordering_forall();
-    // assert forall x:int, y:int  :: 0 < x && 0 < y && 0 <= x*y ==> x <= x*y && y <= x*y;
-
-    lemma_mul_nonzero_forall();
-    // assert forall x:int, y:int  :: x*y != 0 <==> x != 0 && y != 0;
-
-    lemma_mul_nonnegative_forall();
-    // assert forall x:int, y:int  :: 0 <= x && 0 <= y ==> 0 <= x*y;
-
-    lemma_mul_strictly_increases_forall();
-    // assert forall x:int, y:int  :: (1 < x && 0 < y) ==> (y < x*y);
-
-
-    lemma_mul_increases_forall();
-    // assert forall x:int, y:int  :: (0 < x && 0 < y) ==> (y <= x*y);
-}
+{}

--- a/client/test/sampleFolder/timedout_after.dfy
+++ b/client/test/sampleFolder/timedout_after.dfy
@@ -22,7 +22,7 @@
  * SOFTWARE.
 */
 
-lemma lemma_mul_properties()
+lemma lemma_mul_properties() // The error "Timed out after 10 seconds" should be reported here
     ensures forall x:int, y:int  :: x*y == y*x;
     ensures forall x:int :: x*0 == 0*x == 0;
     ensures forall x:int :: x*1 == 1*x == x;

--- a/server/src/backend/verificationResults.ts
+++ b/server/src/backend/verificationResults.ts
@@ -68,7 +68,7 @@ export class VerificationResults {
                 const lineNum: number = parseInt(errors[1], 10) - 1; // 1 based
                 const colNum: number = Math.max(0, parseInt(errors[2], 10) - 1); // 1 based, but 0 can appear in some cases
                 const typeStr: string = errors[3];
-                let msgStr: string = errors[4];
+                let msgStr: string =  errors[4];
 
                 const start: vscode.Position = vscode.Position.create(lineNum, colNum);
                 const end: vscode.Position = vscode.Position.create(lineNum, Number.MAX_VALUE);
@@ -92,6 +92,9 @@ export class VerificationResults {
 
                 if (typeStr === Severity.TimedOut) {
                     msgStr += " (timed out)";
+                } else if (typeStr === Severity.TimedOutAfter)
+                {
+                    msgStr = "Timed out after " + msgStr;
                 }
 
                 lastDiagnostic = vscode.Diagnostic.create(range, msgStr, severity);

--- a/server/src/backend/verificationResults.ts
+++ b/server/src/backend/verificationResults.ts
@@ -68,7 +68,7 @@ export class VerificationResults {
                 const lineNum: number = parseInt(errors[1], 10) - 1; // 1 based
                 const colNum: number = Math.max(0, parseInt(errors[2], 10) - 1); // 1 based, but 0 can appear in some cases
                 const typeStr: string = errors[3];
-                let msgStr: string =  errors[4];
+                let msgStr: string = errors[4];
 
                 const start: vscode.Position = vscode.Position.create(lineNum, colNum);
                 const end: vscode.Position = vscode.Position.create(lineNum, Number.MAX_VALUE);

--- a/server/src/backend/verificationResults.ts
+++ b/server/src/backend/verificationResults.ts
@@ -92,8 +92,7 @@ export class VerificationResults {
 
                 if (typeStr === Severity.TimedOut) {
                     msgStr += " (timed out)";
-                } else if (typeStr === Severity.TimedOutAfter)
-                {
+                } else if (typeStr === Severity.TimedOutAfter) {
                     msgStr = "Timed out after " + msgStr;
                 }
 

--- a/server/src/strings/regexRessources.ts
+++ b/server/src/strings/regexRessources.ts
@@ -1,7 +1,7 @@
 "use strict";
 
 export class Verification {
-    public static LogParseRegex = new RegExp(/\((\d+),(\d+)\):\s*(Error|Warning|Info|Timed out on|Out of memory on|Out of resource on).*?: (.*)/);
+    public static LogParseRegex = new RegExp(/\((\d+),(\d+)\):\s*(?:Verification of.*)?(Error|Warning|Info|timed out after|Timed out on|Out of memory on|Out of resource on)[^:]*?(?::?)\s*(.*)/);
     public static NumberOfProofObligations = new RegExp(/\[(\d+) proof obligation(s|)\]\s+(verified|error)/);
     public static RelatedLocationRegex = new RegExp(/\((\d+),(\d+)\):\s*Related location:\s*(.*)/);
 }

--- a/server/src/strings/stringRessources.ts
+++ b/server/src/strings/stringRessources.ts
@@ -5,6 +5,7 @@ export class Severity {
     public static Warning: string = "Warning";
     public static Info: string = "Info";
     public static TimedOut: string = "Timed out on";
+    public static TimedOutAfter: string = "timed out after";
 }
 
 export class WarningMsg {


### PR DESCRIPTION
Errors like the following are currently not reported by the extension:
`timedout_after.dfy(25,6): Verification of 'Impl$$_module.__default.lemma__mul__properties' timed out after 10 seconds`
which is the error reported when I run the file ` client/test/sampleFolder/timedout_after.dfy` included in this PR on my machine.

This PR fixes this issue.

**Note:** The content of the test file `timedout_after.dfy`` is taken from the IronFleet project as this issue was discovered while verifying the integer number library of IronFleet. Hence, the copyright notice added to it.
If you think that the copyright notice is not required, feel free to remove it.
Also, feel free to replace my example with a different one showing the same type of error.
