### PR TITLE
Fix whitespace character class escape in createWordRegExp

### DIFF
--- a/server/src/vscodeFunctions/wordHelper.ts
+++ b/server/src/vscodeFunctions/wordHelper.ts
@@ -19,7 +19,7 @@ function createWordRegExp(allowInWords: string = ""): RegExp {
         }
         source += "\\" + seperator;
     }
-    source += "\s]+)";
+    source += "\\s]+)";
     return new RegExp(source, "g");
 }
 


### PR DESCRIPTION
This PR fixes a bug that affects go-to definitions and other capabilities utilising `getWordAtText` in `src/vscodeFunctions/wordHelper.ts`. Line 22 appends `\s` to the end of a string containing a regular expression with the intention of matching a whitespace character, but `\s` in a JavaScript string is a redundant escape sequence evaluating to just `s`. Consequently, the `getWordAtText` function recognises the character `s` as a word boundary, and not whitespace.

```
method Thi() { }
method I() { }
method Broken() { }
datatype MyType = ThisIsBroken
```

In the current version of the extension, invoking go-to-definition on `ThisIsBroken` will take you to one of the methods `Thi`, `I`, or `Broken`, depending on where exactly your cursor is.
